### PR TITLE
Remove dependency on `bool_to_option` feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-#![feature(bool_to_option)]
 mod deps;
 mod errors;
 


### PR DESCRIPTION
This effectively allows for the crate to compile on stable